### PR TITLE
Fix BlockSelectionUtil

### DIFF
--- a/src/main/java/com/github/puzzle/game/util/BlockSelectionUtil.java
+++ b/src/main/java/com/github/puzzle/game/util/BlockSelectionUtil.java
@@ -6,26 +6,33 @@ import finalforeach.cosmicreach.blocks.BlockPosition;
 import finalforeach.cosmicreach.blocks.BlockState;
 import finalforeach.cosmicreach.blocks.BlockStateMissing;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 public class BlockSelectionUtil {
 
     public static BlockPosition getBlockPositionLookingAt() {
         try {
-            Class<?> o = Class.forName("finalforeach.cosmicreach.BlockSelection");
-            Method method = Reflection.getMethod(o, "getBlockPositionLookingAt");
-            return (BlockPosition) MethodUtil.runStaticMethod(method);
-        } catch (ClassNotFoundException e) {
+            Class<?> gameState = Class.forName("finalforeach.cosmicreach.gamestates.GameState");
+            Field inGameField = gameState.getDeclaredField("IN_GAME");
+            Object inGame = inGameField.get(null);
+            Object blockSelection = Reflection.getField(inGame, "blockSelection").get(inGame);
+            Method method = Reflection.getMethod(blockSelection.getClass(), "getBlockPositionLookingAt");
+            return (BlockPosition) MethodUtil.runMethod(blockSelection, method);
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
             return new BlockPosition(null, 0, 0, 0);
         }
     }
 
     public static BlockState getBlockLookingAt() {
         try {
-            Class<?> o = Class.forName("finalforeach.cosmicreach.BlockSelection");
-            Method method = Reflection.getMethod(o, "getBlockLookingAt");
-            return (BlockState) MethodUtil.runStaticMethod(method);
-        } catch (ClassNotFoundException e) {
+            Class<?> gameState = Class.forName("finalforeach.cosmicreach.gamestates.GameState");
+            Field inGameField = gameState.getDeclaredField("IN_GAME");
+            Object inGame = inGameField.get(null);
+            Object blockSelection = Reflection.getField(inGame, "blockSelection").get(inGame);
+            Method method = Reflection.getMethod(blockSelection.getClass(), "getBlockLookingAt");
+            return (BlockState) MethodUtil.runMethod(blockSelection, method);
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
             return BlockStateMissing.fromMissingKey("nuhuh");
         }
     }


### PR DESCRIPTION
`BlockSelection` is no longer static and is instead an instance member of `InGame`. This PR updates `BlockSelectionUtil` to use InGame.blockSelection properly.